### PR TITLE
[MONDRIAN-2049] compound slicer members were not factored in aggStar sel...

### DIFF
--- a/src/main/mondrian/rolap/SqlMemberSource.java
+++ b/src/main/mondrian/rolap/SqlMemberSource.java
@@ -690,7 +690,9 @@ RME is this right
 
         // Convert global ordinal to cube based ordinal (the 0th dimension
         // is always [Measures])
-        final Member[] members = evaluator.getNonAllMembers();
+        final Member[] members =
+          SqlConstraintUtils.expandSupportedCalculatedMembers(
+              evaluator.getNonAllMembers(), evaluator);
 
         // if measure is calculated, we can't continue
         if (!(members[0] instanceof RolapBaseCubeMeasure)) {


### PR DESCRIPTION
...ection for Children

fixes NPE with agg enabled in
 NativeSetEvaluationTest.testConstraintCacheIncludesMultiPositionSlicer
 BasicQueryTest.testCompoundSlicerNonEmpty
